### PR TITLE
Removes most bitbucket references to the private repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,9 @@
 # Pattern Library
 
 ## Usage
-This is a private repo only available to deque employees.  To include cauldron in your app you need install it via bower.  This can be done by adding `git@bitbucket.org:dmusser/pattern-library.git#1.0.0` as a dependency.  Example bower.json to include the pattern library:
-```json
-{
-  "name": "my-awesome-app",
-  "description": "just an awesome app",
-  "main": "fred.js",
-  "authors": [
-    "Fred"
-  ],
-  "license": "UNLICENSED",
-  "homepage": "",
-  "private": true,
-  "dependencies": {
-    "pattern-library": "git@bitbucket.org:dmusser/pattern-library.git#1.0.0"
-  }
-}
+```bash
+$ bower install deque-pattern-library
 ```
-__NOTE__: To include the pattern library up above you will need to have SSH setup for your bitbucket account. [Here's how](https://confluence.atlassian.com/bitbucket/set-up-ssh-for-git-728138079.html)
 
 ### Dependencies
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "pattern-library",
-  "description": "Patterns and stuffs",
+  "name": "deque-pattern-library",
+  "description": "Deque Pattern Library",
   "main": "gulpfile.js",
   "authors": [
     "Harris Schneiderman <harris.schneiderman@deque.com>"

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
   "authors": [
     "Harris Schneiderman <harris.schneiderman@deque.com>"
   ],
-  "license": "UNLICENSED",
-  "homepage": "",
+  "license": "MPL-2.0",
+  "homepage": "https://github.com/dequelabs/pattern-library",
   "private": true,
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deque-pattern-library",
   "version": "1.1.0",
-  "description": "",
+  "description": "Deque Pattern Library",
   "main": "dist/js/cauldron.js",
   "scripts": {
     "test": "gulp test"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,25 @@
 {
-  "name": "pattern-library",
+  "name": "deque-pattern-library",
   "version": "1.1.0",
   "description": "",
-  "main": "gulpfile.js",
+  "main": "dist/js/cauldron.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gulp test"
   },
-  "author": "",
+  "author": {
+    "name": "Harris Schneiderman",
+    "organization": "Deque Systems, Inc.",
+    "url": "http://deque.com/"
+  },
   "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/schne324/live-region.git"
+  },
+  "homepage": "https://github.com/schne324/live-region#readme",
+  "bugs": {
+    "url": "https://github.com/schne324/live-region/issues"
+  },
   "devDependencies": {
     "chai": "^3.5.0",
     "gulp": "^3.9.1",


### PR DESCRIPTION
If/when this is merged I'll tag a new bower release under `"deque-pattern-library"`