### PR TITLE
Added audio and video elements

### DIFF
--- a/lib/commons/is-focusable/selector.js
+++ b/lib/commons/is-focusable/selector.js
@@ -14,5 +14,7 @@ module.exports = [
   'object',
   'embed',
   '[tabindex="0"]',
-  '[contenteditable]'
+  '[contenteditable]',
+  'audio[controls]',
+  'video[controls]'
 ].join(', ');


### PR DESCRIPTION
The `<audio>` and `<video>` HTML elements featuring the `controls` attribute should also be included as focusable elements.

Might be able to add a few more as specified from: https://allyjs.io/data-tables/focusable.html.