### PR TITLE
fix: remove content from required to prevent double announcement in SR

### DIFF
--- a/lib/commons/forms.less
+++ b/lib/commons/forms.less
@@ -83,21 +83,18 @@ textarea,
     color: @disabled;
   }
 
-  &@{prefix}required {
-    &:after {
-      content: 'Required';
-      display: inline-block;
-      margin-left: @space-large;
-      font-style: italic;
-      font-weight: @weight-normal;
-    }
-  }
-
   &@{prefix}error {
     &:after {
       color: @error;
     }
   }
+}
+
+@{prefix}required-text {
+  display: inline-block;
+  margin-left: @space-large;
+  font-style: italic;
+  font-weight: @weight-normal;
 }
 
 @{prefix}label-inline {

--- a/lib/commons/forms.less
+++ b/lib/commons/forms.less
@@ -83,18 +83,19 @@ textarea,
     color: @disabled;
   }
 
-  &@{prefix}error {
-    &:after {
-      color: @error;
+  &@{prefix}required {
+    @{prefix}required-text {
+      display: inline-block;
+      margin-left: @space-large;
+      font-style: italic;
+      font-weight: @weight-normal;
+    }
+    &@{prefix}error {
+      @{prefix}required-text {
+        color: @error;
+      }
     }
   }
-}
-
-@{prefix}required-text {
-  display: inline-block;
-  margin-left: @space-large;
-  font-style: italic;
-  font-weight: @weight-normal;
 }
 
 @{prefix}label-inline {


### PR DESCRIPTION
closes #15 
Example:

```html
<label class="dqpl-label" for="password">
    Password
    <span class="dqpl-required-text" aria-hidden="true">Required</span>
</label>
<input class="dqpl-text-input" type="password" id="password" aria-required="true" required/>
```