### PR TITLE
Fix: adds disabled attribute selectors for the disabled styling of primary and secondary buttons ('dqpl-disabled' is still supported)

### DIFF
--- a/lib/components/buttons/style.less
+++ b/lib/components/buttons/style.less
@@ -57,7 +57,9 @@
   background-color: @button-primary;
   color: @button-text-light;
 
-  &@{prefix}disabled {
+  &@{prefix}disabled,
+  &[aria-disabled="true"],
+  &[disabled] {
     color: @text-light-disabled;
   }
 
@@ -76,7 +78,9 @@
   background-color: @button-secondary;
   color: @button-text-dark;
 
-  &@{prefix}disabled {
+  &@{prefix}disabled,
+  &[aria-disabled="true"],
+  &[disabled] {
     color: @disabled;
   }
 


### PR DESCRIPTION
resolves #29 