### PR TITLE
Added summary element

### DIFF
--- a/lib/commons/is-focusable/selector.js
+++ b/lib/commons/is-focusable/selector.js
@@ -16,5 +16,6 @@ module.exports = [
   '[tabindex="0"]',
   '[contenteditable]',
   'audio[controls]',
-  'video[controls]'
+  'video[controls]',
+  summary
 ].join(', ');


### PR DESCRIPTION
This adds the [`summary`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary) element which is the focusable control for the native [`details`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) element.