### PR TITLE
fix: fixes the build ('summary' not `summary` (undefined))

### DIFF
--- a/lib/commons/is-focusable/selector.js
+++ b/lib/commons/is-focusable/selector.js
@@ -17,5 +17,5 @@ module.exports = [
   '[contenteditable]',
   'audio[controls]',
   'video[controls]',
-  summary
+  'summary'
 ].join(', ');


### PR DESCRIPTION
this adds the summary to the focusable selector (which was originally attempted by @svinkle )