### PR TITLE
fix(set-selected): match radios on id rather than element ref

### DIFF
--- a/lib/components/radio-buttons/set-selected.js
+++ b/lib/components/radio-buttons/set-selected.js
@@ -10,19 +10,33 @@ import Classlist from 'classlist';
  */
 module.exports = (radios, newlySelected, focus) => {
   radios.forEach((radio) => {
-    const isNewlySelected = radio === newlySelected;
+    const radioId = radio.nextElementSibling.id;
+    const newlySelectedId = newlySelected.nextElementSibling.id;
+    const isNewlySelected = radioId === newlySelectedId;
     // set attributes / properties / classes
-    radio.tabIndex = isNewlySelected ? 0 : -1;
-    radio.setAttribute('aria-checked', isNewlySelected ? 'true' : 'false');
-    Classlist(radio).toggle('dqpl-selected');
-    if (isNewlySelected && focus) { newlySelected.focus(); }
-
-    // icon state
-    const inner = radio.querySelector('.dqpl-inner-radio');
-    if (inner) {
-      Classlist(inner)
-        .remove(isNewlySelected ? 'fa-circle-o' : 'fa-dot-circle-o')
-        .add(isNewlySelected ? 'fa-dot-circle-o' : 'fa-circle-o');
+    if (isNewlySelected) {
+      newlySelected.tabIndex = 0;
+      newlySelected.setAttribute('aria-checked', 'true');
+      Classlist(newlySelected).toggle('dqpl-selected');
+      if (focus) {
+        newlySelected.focus();
+      }
+      const inner = radio.querySelector('.dqpl-inner-radio');
+      if (inner) {
+        Classlist(inner)
+          .remove('fa-circle-o')
+          .add('fa-dot-circle-o');
+      }
+    } else {
+      radio.tabIndex = -1;
+      radio.setAttribute('aria-checked', 'false');
+      Classlist(radio).toggle('dqpl-selected');
+      const inner = radio.querySelector('.dqpl-inner-radio');
+      if (inner) {
+        Classlist(inner)
+          .remove('fa-dot-circle-o')
+          .add('fa-circle-o');
+      }
     }
   });
 };

--- a/test/components/radio-buttons/set-selected.js
+++ b/test/components/radio-buttons/set-selected.js
@@ -5,12 +5,13 @@ const Classlist = require('classlist');
 const queryAll = require('../../../lib/commons/query-all');
 const Fixture = require('../../fixture');
 const snippet = require('./snippet.html');
+const fire = require('simulant').fire;
 const setSelected = require('../../../lib/components/radio-buttons/set-selected');
 
 describe('components/radio-buttons/set-selected', () => {
   let fixture, radios;
 
-  before(() => fixture = new Fixture());
+  before(() => (fixture = new Fixture()));
 
   beforeEach(() => {
     fixture.create(snippet);
@@ -33,7 +34,10 @@ describe('components/radio-buttons/set-selected', () => {
       const isChecked = i === 1;
       const inner = r.querySelector('.dqpl-inner-radio');
 
-      assert.equal(r.getAttribute('aria-checked'), isChecked ? 'true' : 'false');
+      assert.equal(
+        r.getAttribute('aria-checked'),
+        isChecked ? 'true' : 'false'
+      );
 
       if (isChecked) {
         assert.isTrue(Classlist(r).contains('dqpl-selected'));
@@ -45,5 +49,17 @@ describe('components/radio-buttons/set-selected', () => {
     });
 
     assert.equal(radios[1], document.activeElement);
+  });
+
+  it('should compare ids not element references', () => {
+    const radioWraps = queryAll('.dqpl-radio-wrap', fixture.element);
+    const radioWrap = radioWraps[2];
+    const cloneWrap = radioWrap.cloneNode(true);
+    radioWrap.parentElement.replaceChild(cloneWrap, radioWrap);
+    const clone = cloneWrap.firstElementChild;
+    setSelected(radios, clone, true);
+    // refresh the collection
+    radios = queryAll('.dqpl-radio', fixture.element);
+    assert.equal(clone, document.activeElement);
   });
 });


### PR DESCRIPTION
Issue came up using this function with a React app. React re-rendered 1 or more radios and the collection would no longer select the new elements.