### PR TITLE
fix(set-selected): match radio element ref from live collection

### DIFF
--- a/lib/components/radio-buttons/set-selected.js
+++ b/lib/components/radio-buttons/set-selected.js
@@ -1,6 +1,8 @@
 'use strict';
 
 import Classlist from 'classlist';
+import closest from 'closest';
+import queryAll from '../../commons/query-all';
 
 /**
  * Cleans up previously selected / configures newly selected radio
@@ -9,7 +11,9 @@ import Classlist from 'classlist';
  * @param  {Boolean} focus              If the newlySelected radio should be focused
  */
 module.exports = (radios, newlySelected, focus) => {
-  radios.forEach((radio) => {
+  const group = closest(newlySelected, '[role="radiogroup"]');
+  const _radios = queryAll('[role="radio"]', group);
+  _radios.forEach((radio) => {
     const isNewlySelected = radio === newlySelected;
     // set attributes / properties / classes
     radio.tabIndex = isNewlySelected ? 0 : -1;

--- a/test/components/radio-buttons/set-selected.js
+++ b/test/components/radio-buttons/set-selected.js
@@ -46,4 +46,15 @@ describe('components/radio-buttons/set-selected', () => {
 
     assert.equal(radios[1], document.activeElement);
   });
+
+  it('should compare a live collection of element references', () => {
+    const radioWraps = queryAll('.dqpl-radio-wrap', fixture.element);
+    const radioWrap = radioWraps[2];
+    const cloneWrap = radioWrap.cloneNode(true);
+    radioWrap.parentElement.replaceChild(cloneWrap, radioWrap);
+    const clone = cloneWrap.querySelector('[role="radio"]');
+    assert.notEqual(clone, document.activeElement);
+    setSelected(null, clone, true);
+    assert.equal(clone, document.activeElement);
+  });
 });


### PR DESCRIPTION
The issue came up in a React app when one or more of the radios were re-rendered. This caused events to not fire correctly when trying to select the re-rendered option. There may still be problems with `dqpl:radio:enable` and `dqpl:radio:disable` until another ready event fires.