### PR TITLE
fix: allow for disabled radio groups to have a default selected radio

### DIFF
--- a/lib/components/radio-buttons/get-selected-index.js
+++ b/lib/components/radio-buttons/get-selected-index.js
@@ -4,6 +4,8 @@ import isSelected from '../../commons/is-selected';
 
 module.exports = (radios) => {
   const enableds = radios.filter((r) => r.getAttribute('aria-disabled') !== 'true');
-  const selecteds = enableds.filter(isSelected);
+  const selecteds = radios.filter(isSelected);
+  // attempt to use the selected radio (regardless of enabled state)
+  // defaulting to the first enabled radio (if none in the group are selected)
   return radios.indexOf(selecteds.length ? selecteds[0] : enableds[0]);
 };


### PR DESCRIPTION
We came across a use case of disabled groups to have a selected radio