### PR TITLE
fix: allows for selected icon on disabled+selected radio

### DIFF
--- a/lib/components/radio-buttons/setup.js
+++ b/lib/components/radio-buttons/setup.js
@@ -47,8 +47,7 @@ module.exports = () => {
           radio.appendChild(inner);
         }
 
-        let iconClass = isSelected ? 'fa-dot-circle-o' : 'fa-circle-o';
-        iconClass = isDisabled(radio) ? 'fa-circle' : iconClass;
+        const iconClass = isSelected ? 'fa-dot-circle-o' : 'fa-circle-o';
 
         Classlist(inner)
           .remove('fa-dot-circle-o')

--- a/test/components/radio-buttons/setup.js
+++ b/test/components/radio-buttons/setup.js
@@ -60,7 +60,6 @@ describe('components/radio-buttons/setup', () => {
         const inner = r.querySelector('.dqpl-inner-radio');
         assert.isTrue(!!inner);
         let c = i === selectedIndex ? 'fa-dot-circle-o' : 'fa-circle-o';
-        c = i === disabledIndex ? 'fa-circle' : c;
         assert.isTrue(Classlist(inner).contains(c));
       });
     });


### PR DESCRIPTION
This was setup weird. If, upon _initializing_ the radio was disabled, we prevented it from having the selected icon. Oddly enough, if you programmatically disabled the radios via the custom event, the selected icon would persist (example: click the Disable Radio Buttons button on https://pattern-library.dequelabs.com/components/radio-buttons)