### PR TITLE
fix: remove margin-left from `.dqpl-label`

### DIFF
--- a/lib/commons/forms.less
+++ b/lib/commons/forms.less
@@ -77,7 +77,6 @@ textarea,
   font-size: @text-smaller;
   font-weight: @weight-light;
   margin-bottom: @space-half;
-  margin-left: @space-half;
   cursor: default;
 
   &@{prefix}label-disabled {


### PR DESCRIPTION
Update for issue #70 
https://github.com/dequelabs/pattern-library/issues/70

- Removed `margin-left: @space-half` from *@{prefix}label* class
- Affects checkboxes and field labels

[x] `npm run test` passed