### PR TITLE
chore: adds each individual (componentized) css file to built dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,8 @@ gulp.task('default', [
   'variables',
   'minify-css',
   'minify-js',
-  'extras'
+  'extras',
+  'individual-css'
 ]);
 
 // Empties out dist/
@@ -40,6 +41,14 @@ gulp.task('css', () => {
   ])
     .pipe(less())
     .pipe(concat('pattern-library.css'))
+    .pipe(gulp.dest(path.join(DIST, 'css')));
+});
+
+gulp.task('individual-css', () => {
+  return gulp.src([
+    './lib/**/*.less'
+  ])
+    .pipe(less())
     .pipe(gulp.dest(path.join(DIST, 'css')));
 });
 


### PR DESCRIPTION
dist/css dir now looks like:
```
├── css
|  ├── base.css
|  ├── commons
|  |  ├── animation
|  |  |  └── animation.css
|  |  ├── dropdown.css
|  |  ├── flex.css
|  |  ├── forms.css
|  |  └── scrim.css
|  ├── components
|  |  ├── badges
|  |  |  └── style.css
|  |  ├── buttons
|  |  |  └── style.css
|  |  ├── field-help
|  |  |  └── style.css
|  |  ├── first-time-point
|  |  |  └── style.css
|  |  ├── links
|  |  |  └── style.css
|  |  ├── option-menus
|  |  |  └── style.css
|  |  ├── selects
|  |  |  └── style.css
|  |  ├── tabs
|  |  |  └── style.css
|  |  └── toasts
|  |     └── style.css
|  ├── composites
|  |  ├── alert
|  |  |  └── style.css
|  |  ├── menu
|  |  |  ├── side-bar.css
|  |  |  └── top-bar.css
|  |  ├── modals
|  |  |  └── style.css
|  |  └── tiles
|  |     └── tiles.css
|  ├── layout.css
|  ├── pattern-library.css
|  ├── pattern-library.min.css
|  └── variables.css
```

This can help keep bundle sizes down of consuming apps and is nice to be able to pull in only what you need...example css file usage:

```css
@import 'deque-pattern-library/dist/css/composites/modals/style.css';
@import 'deque-pattern-library/dist/css/components/buttons/style.css';
```