### PR TITLE
fix: prevents top bar dropdown triggers from being double-clicked

### DIFF
--- a/lib/composites/menu/events/main.js
+++ b/lib/composites/menu/events/main.js
@@ -50,6 +50,7 @@ module.exports = (elements) => {
    */
 
   delegate(elements.topBar, '[role="menuitem"][aria-controls]', 'click', (e) => {
+    e.stopPropagation();
     const target = e.delegateTarget;
     // NOTE: the reason this event is delegated rather than being bound directly
     // to the trigger is to support updating the element ref of the trigger dynamically


### PR DESCRIPTION
...this bug was causing the dropdown to not open given clicks directly on the menuitem (`<li />`) because it would get clicked twice (first would open it and second would close it)