### PR TITLE
fix: refactored dropdown click listeners

### DIFF
--- a/lib/composites/menu/events/main.js
+++ b/lib/composites/menu/events/main.js
@@ -19,7 +19,8 @@ module.exports = (elements) => {
 
   document.addEventListener('click', (e) => {
     const target = e.target;
-    const isWithinDropdown = closest(target, '.dqpl-top-bar li[data-dropdown-expanded]');
+    const isWithinDropdown = closest(target, '.dqpl-top-bar [data-dropdown-expanded]');
+    const isMenuTrigger = target.getAttribute('aria-controls');
 
     if (elements.menu && elements.trigger) {
       const isLocked = elements.menu.getAttribute('data-locked') === 'true';
@@ -36,9 +37,8 @@ module.exports = (elements) => {
       elements.trigger.addEventListener('click', onTriggerClick);
     }
 
-    if (!isWithinDropdown) {
+    if (!isWithinDropdown && !isMenuTrigger) {
       const expandedDropdownItem = document.querySelector('[data-dropdown-expanded="true"]');
-
       if (expandedDropdownItem) {
         expandedDropdownItem.click();
       }
@@ -50,12 +50,16 @@ module.exports = (elements) => {
    */
 
   delegate(elements.topBar, '[role="menuitem"][aria-controls]', 'click', (e) => {
-    e.stopPropagation();
     const target = e.delegateTarget;
+    const expandedDropdownItem = document.querySelector('[data-dropdown-expanded="true"]');
+
+    if (expandedDropdownItem && target !== expandedDropdownItem) {
+      expandedDropdownItem.click();
+    }
+
     // NOTE: the reason this event is delegated rather than being bound directly
     // to the trigger is to support updating the element ref of the trigger dynamically
     if (target === elements.trigger) { return; }
-
     toggleSubmenu(target, (dropdown, done) => {
       Classlist(dropdown).toggle('dqpl-dropdown-active');
       const isMenu = dropdown.getAttribute('role') === 'menu';

--- a/lib/composites/menu/events/main.js
+++ b/lib/composites/menu/events/main.js
@@ -19,7 +19,7 @@ module.exports = (elements) => {
 
   document.addEventListener('click', (e) => {
     const target = e.target;
-    const isWithinDropdown = closest(target, '.dqpl-top-bar [data-dropdown-expanded]');
+    const isWithinDropdown = closest(target, '.dqpl-top-bar li[data-dropdown-expanded]');
     const isMenuTrigger = target.getAttribute('aria-controls');
 
     if (elements.menu && elements.trigger) {

--- a/test/composites/menu/events/arrow.js
+++ b/test/composites/menu/events/arrow.js
@@ -29,7 +29,7 @@ describe('composites/menu/events/arrow', () => {
   it('should handle circularity', () => {
     const topBar = fixture.element.querySelector('.dqpl-top-bar');
     const target = topBar.querySelector('[role="menuitem"]');
-    const expected = topBar.querySelector('.dd-trig');
+    const expected = topBar.querySelector('.dd-trig-2');
 
     proxyquire('../../../../lib/composites/menu/events/arrow', {
       '../utils/activate': (t, adjacent) => {

--- a/test/composites/menu/events/main.js
+++ b/test/composites/menu/events/main.js
@@ -86,6 +86,7 @@ describe('composites/menu/events/main', () => {
         assert.equal(dropdown.getAttribute('aria-expanded'), 'true');
         fire(dropdown2, 'click');
         assert.equal(dropdown2.getAttribute('aria-expanded'), 'true');
+        assert.equal(dropdown.getAttribute('aria-expanded'), 'false');
         done();
       }, 400); // give animation/other timeouts a chance to do stuff
     });

--- a/test/composites/menu/events/main.js
+++ b/test/composites/menu/events/main.js
@@ -81,12 +81,11 @@ describe('composites/menu/events/main', () => {
     it('clicking closed dropdown should open that dropdown and close any other open dropdowns', (done) => {
       const dropdown = elements.dropdown;
       const dropdown2 = elements.dropdown2;
-      // dropdown.setAttribute('aria-expanded', 'true');
       fire(dropdown, 'click');
       setTimeout(() => {
+        assert.equal(dropdown.getAttribute('aria-expanded'), 'true');
         fire(dropdown2, 'click');
         assert.equal(dropdown2.getAttribute('aria-expanded'), 'true');
-        assert.equal(dropdown.getAttribute('aria-expanded'), 'false');
         done();
       }, 400); // give animation/other timeouts a chance to do stuff
     });

--- a/test/composites/menu/events/main.js
+++ b/test/composites/menu/events/main.js
@@ -22,7 +22,8 @@ describe('composites/menu/events/main', () => {
       topBarItems: getTopLevels(topBar.querySelector('[role="menubar"]'), true),
       trigger: topBar.querySelector('.dqpl-menu-trigger'),
       scrim: document.getElementById('dqpl-side-bar-scrim'),
-      dropdown: topBar.querySelector('.dqpl-dropdown')
+      dropdown: topBar.querySelector('#drop-1'),
+      dropdown2: topBar.querySelector('#drop-2')
     };
 
     main(elements); // attach the main events only once as they are delegated
@@ -72,9 +73,22 @@ describe('composites/menu/events/main', () => {
       assert.equal(dropdown.getAttribute('aria-expanded'), 'false');
       fire(elements.topBar.querySelector('#drop-1'), 'click');
       setTimeout(() => {
-      assert.equal(dropdown.getAttribute('aria-expanded'), 'true');
+        assert.equal(dropdown.getAttribute('aria-expanded'), 'true');
         done();
-      }, 400); // give animation/other timeouts a change to do stuff
+      }, 400); // give animation/other timeouts a chance to do stuff
+    });
+
+    it('clicking closed dropdown should open that dropdown and close any other open dropdowns', (done) => {
+      const dropdown = elements.dropdown;
+      const dropdown2 = elements.dropdown2;
+      // dropdown.setAttribute('aria-expanded', 'true');
+      fire(dropdown, 'click');
+      setTimeout(() => {
+        fire(dropdown2, 'click');
+        assert.equal(dropdown2.getAttribute('aria-expanded'), 'true');
+        assert.equal(dropdown.getAttribute('aria-expanded'), 'false');
+        done();
+      }, 400); // give animation/other timeouts a chance to do stuff
     });
   });
 

--- a/test/composites/menu/snippet.html
+++ b/test/composites/menu/snippet.html
@@ -1,22 +1,32 @@
 <div class="dqpl-top-bar">
   <ul role="menubar">
-    <li class="dqpl-menu-trigger" role="menuitem" tabindex="0" aria-label="Menu" aria-controls="dqpl-side-bar" aria-haspopup="true">
+    <li class="dqpl-menu-trigger" role="menuitem" tabindex="0" aria-label="Menu" aria-controls="dqpl-side-bar"
+      aria-haspopup="true">
       <div class="fa fa-bars" role="presentation" aria-hidden="true"></div>
     </li>
-    <li class="second-item" role="menuitem" tabindex="-1"><a href="/" tabindex="-1"><img src="/img/deque-logo-topbar.png" alt="Deque"/></a></li>
-    <li role="menuitem" class="dd-trig" aria-haspopup="true" aria-controls="drop-1">
+    <li class="second-item" role="menuitem" tabindex="-1"><a href="/" tabindex="-1"><img
+          src="/img/deque-logo-topbar.png" alt="Deque" /></a></li>
+    <li role="menuitem" class="dd-trig" aria-haspopup="true" aria-controls="drop-1" tabindex="-1">
       <div>Foo</div>
       <div id="drop-1" role="menu" class="dqpl-dropdown" aria-expanded="false">
         <div role="menuitem" tabindex="-1">Hello</div>
         <div role="menuitem" tabindex="-1">World</div>
       </div>
     </li>
+    <li role="menuitem" class="dd-trig-2" aria-haspopup="true" aria-controls="drop-2" tabindex="-1">
+      <div>Bar</div>
+      <div id="drop-2" role="menu" class="dqpl-dropdown" aria-expanded="false">
+        <div role="menuitem" tabindex="-1">Hello Hello</div>
+        <div role="menuitem" tabindex="-1">World World</div>
+      </div>
+    </li>
   </ul>
 </div>
 <ul class="dqpl-side-bar dqpl-main-nav" id="dqpl-side-bar" role="menu" aria-expanded="false">
   <li class="dqpl-branding" role="menuitem" tabindex="0"><a href="/" tabindex="-1">
-      <div class="dqpl-logo"><img src="/img/deque-logo-topbar.png" alt="Deque"/></div>
-      <div class="dqpl-name">Styleguide</div></a></li>
+      <div class="dqpl-logo"><img src="/img/deque-logo-topbar.png" alt="Deque" /></div>
+      <div class="dqpl-name">Styleguide</div>
+    </a></li>
   <li role="menuitem" tabindex="-1"><a href="/overview" tabindex="-1">Overview</a></li>
   <li role="menuitem" aria-controls="dqpl-components" aria-haspopup="true" tabindex="-1">
     <div class="dqpl-item-text">Components</div>


### PR DESCRIPTION
`e.stopPropagation` was preventing adding other click listeners. Refactored to work without that `e.stopPropagation` 

Dropdown should now open when trigger is clicked and when a separate dropdown is clicked it will close all other drop down menus in the top bar.