### PR TITLE
fix(topbar): dropdown down/up arrows go the correct way

### DIFF
--- a/lib/composites/menu/events/arrow.js
+++ b/lib/composites/menu/events/arrow.js
@@ -3,7 +3,7 @@
 import activate from '../utils/activate';
 
 module.exports = (items, target, dir) => {
-  const isNext = dir === 'next';
+  const isNext = dir === 'next' || dir === 'down';
   const currentIdx = items.indexOf(target);
   let adjacent = items[isNext ? currentIdx + 1 : currentIdx - 1];
   // circularity


### PR DESCRIPTION
Keyboarding within a dropdown the up/down arrows are backwards. Adding `down` to the isNext check corrects this.