### PR TITLE
fix(button): makes buttons display: inline-block (like native implementation)

### DIFF
--- a/lib/base.less
+++ b/lib/base.less
@@ -29,7 +29,7 @@ body {
   }
 
   button, [role="button"] {
-    display: block;
+    display: inline-block;
     zoom: 1;
     line-height: normal;
     white-space: nowrap;


### PR DESCRIPTION
closes: #109 
closes: https://github.com/dequelabs/cauldron-react/issues/82

BREAKING CHANGE: converted buttons from `display: block` to `display: inline-block`

To make buttons display as they used to, do something like:

```css
.App button {
  display: inline-block;
}
```