### PR TITLE
fix: uses absolute position for an open modal to prevent moving sibling elements

### DIFF
--- a/lib/composites/modals/style.less
+++ b/lib/composites/modals/style.less
@@ -7,6 +7,7 @@
 
   &@{prefix}dialog-show {
     display: block;
+    position: absolute;
   }
 
   @{prefix}dialog-inner {


### PR DESCRIPTION
closes issue: #113 