### PR TITLE
feat: position ftpos absolutely

### DIFF
--- a/lib/components/first-time-point/style.less
+++ b/lib/components/first-time-point/style.less
@@ -1,7 +1,7 @@
 @import "../../variables.less";
 
 @{prefix}pointer-wrap {
-  position: relative;
+  position: absolute;
 
   @{prefix}arrow {
     position: absolute;


### PR DESCRIPTION
This is a breaking change, but #125 is already breaking. Will need to update the pattern library demo site after this gets merged.

fixes #118

BREAKING CHANGE: ftpos position is changed from `relative` to `absolute`