### PR TITLE
fix: set `dqpl-toast` to `display:flex`

### DIFF
--- a/lib/components/toasts/style.less
+++ b/lib/components/toasts/style.less
@@ -1,6 +1,7 @@
 @import "../../variables.less";
 
 @{prefix}toast {
+  display: flex;
   top: @top-bar-height;
   position: fixed;
   color: @top-bar-bg-active;


### PR DESCRIPTION
Was fixing a css issue in cauldron react and then noticed this as well. So putting in a fix.

Closes Issue: https://github.com/dequelabs/cauldron-react/issues/217